### PR TITLE
Fix Text-to-Speech

### DIFF
--- a/background.js
+++ b/background.js
@@ -146,8 +146,10 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
       case 'tts':
       if (last_translation.succeeded) {
         console.log("tts: " + last_translation.word + ", sl: " + last_translation.sl);
-        _gaq.push(['_trackEvent', 'tts', last_translation.sl, last_translation.tl]);
-        $('<audio autoplay src="http://translate.google.com/translate_tts?q='+last_translation.word+'&tl='+last_translation.sl+'"></audio>');
+        var msg = new SpeechSynthesisUtterance();
+        msg.lang = last_translation.sl;
+        msg.text = last_translation.word;
+        speechSynthesis.speak(msg);
       }
       sendResponse({});
       break;


### PR DESCRIPTION
The existing TTS method was broken because the `audio` DOM-element which
was being rendered relied on Google serving back an audio file when a
query is made against the Google TTS endpoint. This endpoint now has a
captcha by default.

Instead `SpeechSynthesisUtterance` is used to request TTS from the
Chrome browser without the need for a direct URL request.