### PR TITLE
Fix hover menus closing unintentionally

### DIFF
--- a/lib/popup.html
+++ b/lib/popup.html
@@ -31,6 +31,16 @@
       -webkit-font-smoothing: antialiased;
       font-smoothing: antialiased;
       text-rendering: optimizeLegibility;
+
+      /* To fix the following issue:
+      1. Have translate on hover enabled (opposed to translate on click).
+      2. Wisit a website that has a dropdown menu that opens on hover.
+      3. Open the menu.
+      4. Hover over a word within that menu.
+      5. Incidentally move the cursor over the TransOver popup.
+      The hover menu gets closed.
+      */
+      pointer-events: none;
     }
 
     .pos_translation {


### PR DESCRIPTION
See issue description in the source code.

Example website with that issue: https://www.ebay.com/ (try hovering over categories below the search bar).

![image](https://user-images.githubusercontent.com/39462442/79060480-09e43980-7cb8-11ea-8fbe-4336149c9982.png)