### PR TITLE
perf: do not include 'debug' module in production build

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -1,6 +1,12 @@
 import TransOver from './lib/transover_utils'
 import TransOverLanguages from './lib/languages'
-const debug = require('debug')('transover')
+
+let debug
+if (process.env.NODE_ENV !== 'production') {
+  debug = require('debug')('transover')
+} else {
+  debug = () => {}
+}
 
 let options
 let disable_on_this_page
@@ -146,7 +152,7 @@ document.addEventListener('visibilitychange', function () {
   }
 }, false)
 
-function process(e) {
+function processEvent(e) {
 
   function getHitWord(e) {
 
@@ -345,11 +351,11 @@ $(document).on('mousestop', function(e) {
     // translate selection unless 'translate selection on alt only' is set
     if (window.getSelection().toString()) {
       if (!options.selection_key_only) {
-        process(e)
+        processEvent(e)
       }
     } else {
       if (options.translate_by == 'point') {
-        process(e)
+        processEvent(e)
       }
     }
   })
@@ -362,7 +368,7 @@ $(document).click(function(e) {
     if ($(e.target).closest('a').length > 0)
       return
 
-    process(e)
+    processEvent(e)
   })
   return true
 })

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "babel-loader": "^8.0.5",
     "clean-webpack-plugin": "^1.0.0",
     "copy-webpack-plugin": "^4.6.0",
+    "debug": "^4.1.1",
     "eslint": "^5.11.0",
     "webpack": "^4.28.2",
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "debug": "^4.1.1",
     "jquery": "^3.3.1",
     "xregexp": "^4.2.0"
   }


### PR DESCRIPTION
This reduces stat size of the content script by 20 KB.

Did a smoke test, looks fine.