### PR TITLE
Prevent Chrome page translation tool translating popup

### DIFF
--- a/lib/popup.html
+++ b/lib/popup.html
@@ -65,5 +65,5 @@
     }
   </style>
 
-  <main></main>
+  <main translate="no"></main>
 </template>

--- a/lib/tat_popup.html
+++ b/lib/tat_popup.html
@@ -102,7 +102,7 @@
     }
   </style>
 
-  <main>
+  <main translate="no">
     <div id="top_row_container">
       <div id="disable_on_this_page_container">
         <label><input id="disable_on_this_page" type="checkbox"/>Disable on this site</label>


### PR DESCRIPTION
By adding the translate="no" attributes to the popup <main> tags, the extension is compatible with Google Chrome's built in translate tool. This is very useful for using the 'Always Translate ...' function, since it stops the tool auto translating the pop ups back into the foreign language