### PR TITLE
add 'Disable everywhere' option

### DIFF
--- a/background.js
+++ b/background.js
@@ -251,6 +251,13 @@ async function contentScriptListener(request) {
       }
     }
     break
+  case 'toggle_disable_everywhere':
+    if (request.disable_everywhere) {
+      await Options.disable_everywhere(1)
+    } else {
+      await Options.disable_everywhere(0)
+    }
+    break
   default:
     console.error('Unknown request', JSON.stringify(request, null, 2))
     return {}

--- a/lib/options.js
+++ b/lib/options.js
@@ -117,5 +117,12 @@ export default {
     }
     const fontSize = await localStorage.get('fontSize')
     return parseInt(fontSize || 14)
-  }
+  },
+
+  disable_everywhere: async function(arg) {
+    if (arg != undefined) {
+      return await localStorage.set('disable_everywhere', arg)
+    }
+    return parseInt( await localStorage.get('disable_everywhere') ) || 0
+  },
 }

--- a/lib/tat_popup.html
+++ b/lib/tat_popup.html
@@ -104,6 +104,9 @@
 
   <main translate="no">
     <div id="top_row_container">
+      <div id="disable_everywhere_container">
+        <label><input id="disable_everywhere" type="checkbox"/>Disable everywhere</label>
+      </div>
       <div id="disable_on_this_page_container">
         <label><input id="disable_on_this_page" type="checkbox"/>Disable on this site</label>
       </div>

--- a/lib/tat_popup.js
+++ b/lib/tat_popup.js
@@ -1,6 +1,6 @@
 class TatPopupTransover extends HTMLElement {
   static get observedAttributes() {
-    return ['data-languages', 'data-disable_on_this_page']
+    return ['data-languages', 'data-disable_on_this_page', 'data-disable_everywhere']
   }
 
   constructor() {
@@ -68,6 +68,13 @@ class TatPopupTransover extends HTMLElement {
       }, '*')
     }
 
+    this.q('#disable_everywhere').onchange = (e) => {
+      window.postMessage({
+        type: 'toggle_disable_everywhere',
+        disable_everywhere: e.target.checked
+      }, '*')
+    }
+
     this.q('#tat_close').onclick = (e) => {
       window.postMessage({type: 'tat_close'})
       e.preventDefault()
@@ -116,6 +123,8 @@ class TatPopupTransover extends HTMLElement {
       }
     } else if (attribute === 'data-disable_on_this_page') {
       this.q('#disable_on_this_page').checked = JSON.parse(newVal)
+    } else if (attribute === 'data-disable_everywhere') {
+      this.q('#disable_everywhere').checked = JSON.parse(newVal)
     }
   }
 


### PR DESCRIPTION
For a way of toggling the extension globally that's more convenient than disabling and re-enabling it in the browser's _Manage Your Extensions_ view, a `Disable everywhere` option is added to TransOver. It works in the same way as `Disable on this site`, except that it toggles the extension for all sites.